### PR TITLE
removes trailing slash from new_url in script.js

### DIFF
--- a/field/assets/js/script.js
+++ b/field/assets/js/script.js
@@ -52,7 +52,7 @@
 
         if(r.class == 'success' && r.uri) {
           container.show().html(r.message).addClass(r.class);
-          new_url = window.location.href.replace(/(pages\/.*\/edit.*)/g, 'pages/' + r.uri + '/edit/');
+          new_url = window.location.href.replace(/(pages\/.*\/edit.*)/g, 'pages/' + r.uri + '/edit');
           container.append('You will be redirected to the new page ...')
           setTimeout(function () {
               window.location.replace(new_url);


### PR DESCRIPTION
I'm not sure if it's just a wrong configuration with my setup but for me the redirect (after the page was successfully cloned) to `https://mydomain.com/panel/pages/new/page/uri/edit/` returns an error.

After removing the trailing slash from the new url everything works as expected. I had a look at the original [panel route](https://github.com/getkirby/panel/blob/73db1d731efb50c0edd768a1254228c56d7564dd/app/config/routes.php#L223) and there's no trailing slash as well.

Could you please check, if it works for you without the trailing slash, too? If so, it might be the better (more robust) way?!

… and of course: Thanks for this usefull plugin! 👏 